### PR TITLE
[OWL-291] use the short hostname instead when agent uploads metrics

### DIFF
--- a/g/cfg.go
+++ b/g/cfg.go
@@ -5,6 +5,7 @@ import (
 	"github.com/toolkits/file"
 	"log"
 	"os"
+	"strings"
 	"sync"
 )
 
@@ -73,6 +74,10 @@ func Hostname() (string, error) {
 	if err != nil {
 		log.Println("ERROR: os.Hostname() fail", err)
 	}
+	// hostname -s
+	// -s, --short
+	// Display the short host name. This is the host name cut at the first dot.
+	hostname = strings.Split(hostname, ".")[0]
 	return hostname, err
 }
 


### PR DESCRIPTION
```
modified:   g/cfg.go

// hostname -s
// -s, --short
// Display the short host name. This is the host name cut at the first dot.
hostname = strings.Split(hostname, ".")[0]
```
