### PR TITLE
[OWL-479] Agent adds exe file permission to plugin before it runs

### DIFF
--- a/plugins/scheduler_test.go
+++ b/plugins/scheduler_test.go
@@ -1,0 +1,35 @@
+package plugins
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var filePath string
+
+func TestSetFileMod(t *testing.T) {
+	var in_mode os.FileMode = 0744
+	setFileMod(filePath, in_mode)
+
+	info, _ := os.Stat(filePath)
+	expected_mode := info.Mode()
+	if expected_mode != in_mode {
+		t.Error("Set file mode fail!")
+	}
+}
+
+func TestMain(m *testing.M) {
+	filePath = "____________testfile_________________"
+	_, err := os.Create(filePath)
+	if err != nil {
+		fmt.Println("Create test file failed:", filePath, err)
+	}
+
+	m.Run()
+
+	err = os.Remove(filePath)
+	if err != nil {
+		fmt.Println("Remove test file failed:", filePath, err)
+	}
+}


### PR DESCRIPTION
Originally, plugin files easily get stuck because of file permission problems. Fix this problem in this issue.
### How to verify:
1. Build the binary and run the agent. 
2. Setup the agent to let it pull plugin from git. Tutorial is here:  [wiki](http://wiki.cepave.com/display/OWL/Agent+Plugin) 
3. Login to the agent.  
   `docker exec -ti agent /bin/bash`
4. Inside the agent, check the plugin directory.  
   `chmod -x script_file`
5. Observe for a while, the script file will be chmod to 744
